### PR TITLE
Feature/display quote from category

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -14,7 +14,7 @@ const App = () => {
   }
 
   const generateQuote = async () => {
-    const url = `https://api.quotable.io/random?tags=${category.toLowerCase()}`
+    const url = `https://api.quotable.io/random?tags=${category}`
     const data = await fetchData(url)
     setQuote(data.content)
   }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -2,14 +2,45 @@ import React, { useState, useEffect } from 'react'
 import Header from '../Header/Header.js'
 import Message from '../Message/Message.js'
 import Selector from '../Selector/Selector.js'
+import { fetchData } from '../../utils/api.js'
 import './App.css'
 
 const App = () => {
   const [category, setCategory] = useState(null)
+  const [quote, setQuote] = useState(null)
+
+  // method to update the chosen category, passed to Selector 
+  const chooseCategory = choice => {
+    setCategory(choice)
+  }
+
+  // also determine the quote, and pass that to message
+  const generateQuote = async () => {
+    const url = `https://api.quotable.io/random?tags=${category}`
+    const data = await fetchData(url)
+    console.log('quote data', data)
+    setQuote(data)
+  }
+
+  /*
+  useEffect(() => {
+    const generateQuote = async () => {
+      const url = `https://api.quotable.io/random?tags=${category}`
+      const data = await fetchData(url)
+      console.log('quote data', data)
+      setQuote(data)
+    }
+
+    generateQuote()
+  }, [])
+  */
+  
   return (
     <div>
       <Header />
-      <Selector />
+      <Selector 
+        chooseCategory={chooseCategory}
+        />
       <Message />
     </div>
   )

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,13 +1,13 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import Header from '../Header/Header.js'
 import Message from '../Message/Message.js'
 import Selector from '../Selector/Selector.js'
 import './App.css'
 
 const App = () => {
+  const [category, setCategory] = useState(null)
   return (
     <div>
-      <h1>App</h1>
       <Header />
       <Selector />
       <Message />
@@ -15,4 +15,4 @@ const App = () => {
   )
 }
 
-export default App;
+export default App

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import Header from '../Header/Header.js'
 import Message from '../Message/Message.js'
 import Selector from '../Selector/Selector.js'
@@ -9,39 +9,26 @@ const App = () => {
   const [category, setCategory] = useState(null)
   const [quote, setQuote] = useState(null)
 
-  // method to update the chosen category, passed to Selector 
   const chooseCategory = choice => {
     setCategory(choice)
   }
 
-  // also determine the quote, and pass that to message
   const generateQuote = async () => {
-    const url = `https://api.quotable.io/random?tags=${category}`
+    const url = `https://api.quotable.io/random?tags=${category.toLowerCase()}`
     const data = await fetchData(url)
-    console.log('quote data', data)
-    setQuote(data)
+    setQuote(data.content)
   }
-
-  /*
-  useEffect(() => {
-    const generateQuote = async () => {
-      const url = `https://api.quotable.io/random?tags=${category}`
-      const data = await fetchData(url)
-      console.log('quote data', data)
-      setQuote(data)
-    }
-
-    generateQuote()
-  }, [])
-  */
   
   return (
     <div>
       <Header />
       <Selector 
         chooseCategory={chooseCategory}
-        />
-      <Message />
+        generateQuote={generateQuote}
+      />
+      <Message 
+        quote={quote}
+      />
     </div>
   )
 }

--- a/src/components/Message/Message.js
+++ b/src/components/Message/Message.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import './Message.css'
 
-const Message = () => {
+const Message = ({quote}) => {
   return (
     <div>
-      <h3>Something clever will go here soon...</h3>
+      {!quote && <h3>Something clever will go here soon...</h3>}
+      {quote && <h3>{quote}</h3>}
       <button></button>
     </div>
   )

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -3,7 +3,7 @@ import './Selector.css'
 import { fetchData } from '../../utils/api.js'
 import capitalize from '../../utils/capitalize.js'
 
-const Selector = () => {
+const Selector = ({chooseCategory}) => {
   const [quote, setQuote] = useState(null)
   const [categories, setCategories] = useState([])
 

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -4,7 +4,6 @@ import { fetchData } from '../../utils/api.js'
 import capitalize from '../../utils/capitalize.js'
 
 const Selector = ({chooseCategory, generateQuote}) => {
-  const [quote, setQuote] = useState(null)
   const [categories, setCategories] = useState([])
 
   useEffect(() => {
@@ -17,40 +16,22 @@ const Selector = ({chooseCategory, generateQuote}) => {
     generateCategories()
   }, [])
 
-  useEffect(() => {
-    const result = async () => {
-      const url = 'https://api.quotable.io/random'
-      const data = await fetchData(url)
-      setQuote(data.content)
-    }
-
-    result()
-  }, [])
-
   const displayCategories = () => (
     categories.map(category => {
-      const {quoteCount, _id} = category
-      let {name} = category
-      let result
-      name = capitalize(name) 
-      if (quoteCount) { 
-        result = (
-          <option 
-            value={name}
-            key={_id}
-          >
-          {name}
-          </option>
-        )
-      }
-
-      return result
+      const {name, quoteCount, _id} = category
+      return quoteCount ? (
+        <option 
+          value={name}
+          key={_id}
+        >
+        {capitalize(name)}
+        </option>
+      ) : null
     })
   )
 
   return (
     <div>
-      <h2>{quote}</h2>
       <form>
         <select
           onChange={e => chooseCategory(e.target.value)}

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -3,7 +3,7 @@ import './Selector.css'
 import { fetchData } from '../../utils/api.js'
 import capitalize from '../../utils/capitalize.js'
 
-const Selector = ({chooseCategory}) => {
+const Selector = ({chooseCategory, generateQuote}) => {
   const [quote, setQuote] = useState(null)
   const [categories, setCategories] = useState([])
 
@@ -52,12 +52,20 @@ const Selector = ({chooseCategory}) => {
     <div>
       <h2>{quote}</h2>
       <form>
-        <select>
+        <select
+          onChange={e => chooseCategory(e.target.value)}
+        >
           <option value=''>
             Please pick a category
           </option>
           {displayCategories()}
         </select>
+      <button
+        onClick={e => {
+          e.preventDefault()
+          generateQuote()
+        }}
+      ></button>
       </form>
     </div>
   )


### PR DESCRIPTION
## Is this a fix or a feature?
- feature
## What is the change/fix?
- puts category selection in state
- then, upon button click, generates quote from category
- removes default quote living in `Selector`
## This PR is related to which issues:
- Closes #14
## Screenshots(if appropriate)
![image](https://user-images.githubusercontent.com/70294115/110059223-05d26780-7d21-11eb-9976-b396dedc975a.png)
## Any known issues?
- if button is clicked before a category is selected, we get an error